### PR TITLE
Gemm! to avoid allocation

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -83,7 +83,7 @@ function to_host{T}(Mat::CudaSparseMatrixCSR{T})
         I[counter] = row
         counter += 1
     end
-    return sparse(I,colVal,nzVal)
+    return sparse(I,colVal,nzVal,Mat.dims[1],Mat.dims[2])
 end
 
 summary(g::CudaSparseMatrix) = string(g)


### PR DESCRIPTION
I suggest adding a function like gemm! below to avoid unnecessary allocation when you repeatedly perform the same operation with similar arrays (as it happens in deep learning).  You provide a target sparse matrix, its fields only get reallocated if necessary.  I did not provide indexa, indexb, indexc separately as I am not sure if this is necessary.
