### PR TITLE
Some more 0.6 fixes

### DIFF
--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -676,14 +676,12 @@ end
 
 ## level 2 functions
 
-"""
+@doc """
     mv!(transa::SparseChar, alpha::BlasFloat, A::CudaSparseMatrix, X::CudaVector, beta::BlasFloat, Y::CudaVector, index::SparseChar)
 
 Performs `Y = alpha * op(A) *X + beta * Y`, where `op` can be nothing (`transa = N`), tranpose (`transa = T`)
 or conjugate transpose (`transa = C`). `X` is a sparse vector, and `Y` is dense.
-"""
-function mv!(transa::SparseChar, alpha::BlasFloat, A::CudaSparseMatrix, X::CudaVector,
-             beta::BlasFloat, Y::CudaVector, index::SparseChar) end
+""" mv!
 for (fname,elty) in ((:cusparseSbsrmv, :Float32),
                      (:cusparseDbsrmv, :Float64),
                      (:cusparseCbsrmv, :Complex64),

--- a/src/util.jl
+++ b/src/util.jl
@@ -15,14 +15,14 @@ using Compat
 """
 Container to hold sparse vectors on the GPU, similar to `SparseVector` in base Julia.
 """
-type CudaSparseVector{Tv} <: AbstractCudaSparseVector{Tv}
+@compat type CudaSparseVector{Tv} <: AbstractCudaSparseVector{Tv}
     iPtr::CudaArray{Cint,1}
     nzVal::CudaArray{Tv,1}
     dims::NTuple{2,Int}
     nnz::Cint
     dev::Int
-    function CudaSparseVector{Tv}(iPtr::CudaVector{Cint}, nzVal::CudaVector{Tv}, dims::Int, nnz::Cint, dev::Int)
-        new(iPtr,nzVal,(dims,1),nnz,dev)
+    function (::Type{CudaSparseVector{Tv}}){Tv}(iPtr::CudaVector{Cint}, nzVal::CudaVector{Tv}, dims::Int, nnz::Cint, dev::Int)
+        new{Tv}(iPtr,nzVal,(dims,1),nnz,dev)
     end
 end
 
@@ -33,7 +33,7 @@ the GPU, similar to `SparseMatrixCSC` in base Julia.
 **Note**: Most CUSPARSE operations work with CSR formatted matrices, rather
 than CSC.
 """
-type CudaSparseMatrixCSC{Tv} <: AbstractCudaSparseMatrix{Tv}
+@compat type CudaSparseMatrixCSC{Tv} <: AbstractCudaSparseMatrix{Tv}
     colPtr::CudaArray{Cint,1}
     rowVal::CudaArray{Cint,1}
     nzVal::CudaArray{Tv,1}
@@ -41,8 +41,8 @@ type CudaSparseMatrixCSC{Tv} <: AbstractCudaSparseMatrix{Tv}
     nnz::Cint
     dev::Int
 
-    function CudaSparseMatrixCSC{Tv}(colPtr::CudaVector{Cint}, rowVal::CudaVector{Cint}, nzVal::CudaVector{Tv}, dims::NTuple{2,Int}, nnz::Cint, dev::Int)
-        new(colPtr,rowVal,nzVal,dims,nnz,dev)
+    function (::Type{CudaSparseMatrixCSC{Tv}}){Tv}(colPtr::CudaVector{Cint}, rowVal::CudaVector{Cint}, nzVal::CudaVector{Tv}, dims::NTuple{2,Int}, nnz::Cint, dev::Int)
+        new{Tv}(colPtr,rowVal,nzVal,dims,nnz,dev)
     end
 end
 
@@ -53,7 +53,7 @@ GPU.
 **Note**: Most CUSPARSE operations work with CSR formatted matrices, rather
 than CSC.
 """
-type CudaSparseMatrixCSR{Tv} <: AbstractCudaSparseMatrix{Tv}
+@compat type CudaSparseMatrixCSR{Tv} <: AbstractCudaSparseMatrix{Tv}
     rowPtr::CudaArray{Cint,1}
     colVal::CudaArray{Cint,1}
     nzVal::CudaArray{Tv,1}
@@ -61,8 +61,8 @@ type CudaSparseMatrixCSR{Tv} <: AbstractCudaSparseMatrix{Tv}
     nnz::Cint
     dev::Int
 
-    function CudaSparseMatrixCSR{Tv}(rowPtr::CudaVector{Cint}, colVal::CudaVector{Cint}, nzVal::CudaVector{Tv}, dims::NTuple{2,Int}, nnz::Cint, dev::Int)
-        new(rowPtr,colVal,nzVal,dims,nnz,dev)
+    function (::Type{CudaSparseMatrixCSR{Tv}}){Tv}(rowPtr::CudaVector{Cint}, colVal::CudaVector{Cint}, nzVal::CudaVector{Tv}, dims::NTuple{2,Int}, nnz::Cint, dev::Int)
+        new{Tv}(rowPtr,colVal,nzVal,dims,nnz,dev)
     end
 end
 
@@ -71,7 +71,7 @@ Container to hold sparse matrices in block compressed sparse row (BSR) format on
 the GPU. BSR format is also used in Intel MKL, and is suited to matrices that are
 "block" sparse - rare blocks of non-sparse regions.
 """
-type CudaSparseMatrixBSR{Tv} <: AbstractCudaSparseMatrix{Tv}
+@compat type CudaSparseMatrixBSR{Tv} <: AbstractCudaSparseMatrix{Tv}
     rowPtr::CudaArray{Cint,1}
     colVal::CudaArray{Cint,1}
     nzVal::CudaArray{Tv,1}
@@ -81,8 +81,8 @@ type CudaSparseMatrixBSR{Tv} <: AbstractCudaSparseMatrix{Tv}
     nnz::Cint
     dev::Int
 
-    function CudaSparseMatrixBSR{Tv}(rowPtr::CudaVector{Cint}, colVal::CudaVector{Cint}, nzVal::CudaVector{Tv}, dims::NTuple{2,Int},blockDim::Cint, dir::SparseChar, nnz::Cint, dev::Int)
-        new(rowPtr,colVal,nzVal,dims,blockDim,dir,nnz,dev)
+    function (::Type{CudaSparseMatrixBSR{Tv}}){Tv}(rowPtr::CudaVector{Cint}, colVal::CudaVector{Cint}, nzVal::CudaVector{Tv}, dims::NTuple{2,Int},blockDim::Cint, dir::SparseChar, nnz::Cint, dev::Int)
+        new{Tv}(rowPtr,colVal,nzVal,dims,blockDim,dir,nnz,dev)
     end
 end
 
@@ -92,14 +92,14 @@ HYB format is an opaque struct, which can be converted to/from using
 CUSPARSE routines.
 """
 @compat const cusparseHybMat_t = Ptr{Void}
-type CudaSparseMatrixHYB{Tv} <: AbstractCudaSparseMatrix{Tv}
+@compat type CudaSparseMatrixHYB{Tv} <: AbstractCudaSparseMatrix{Tv}
     Mat::cusparseHybMat_t
     dims::NTuple{2,Int}
     nnz::Cint
     dev::Int
 
-    function CudaSparseMatrixHYB(Mat::cusparseHybMat_t, dims::NTuple{2,Int}, nnz::Cint, dev::Int)
-        new(Mat,dims,nnz,dev)
+    function (::Type{CudaSparseMatrixHYB{Tv}}){Tv}(Mat::cusparseHybMat_t, dims::NTuple{2,Int}, nnz::Cint, dev::Int)
+        new{Tv}(Mat,dims,nnz,dev)
     end
 end
 


### PR DESCRIPTION
Not sure about the ambiguity fix, tagging the doc to `mv!` is quite coarse. For reference, the error was:

```
MethodError:

mv!(
    ::Char,
    ::Float32,
    ::CUSPARSE.CudaSparseMatrixCSR{Float32},
    ::CUDArt.CudaArray{Float32,1},
    ::Float32,
    ::CUDArt.CudaArray{Float32,1},
    ::Char)
is ambiguous. Candidates:

mv!(
    transa::Char,
    alpha::Union{Complex{Float32}, Complex{Float64}, Float32, Float64}
    A::Union{CUSPARSE.CudaSparseMatrixBSR{T}, CUSPARSE.CudaSparseMatrixCSC{T}, CUSPARSE.CudaSparseMatrixCSR{T}, CUSPARSE.CudaSparseMatrixHYB{T}} where T
    X::CUDArt.CudaArray{T,1} where T, beta::Union{Complex{Float32}, Complex{Float64}, Float32, Float64}
    Y::CUDArt.CudaArray{T,1} where T
    index::Char)
in CUSPARSE at /home/tbesard/Projects/Julia-CUDA/CUSPARSE/src/sparse.jl:686

mv!(
    transa::Char,
    alpha::Float32
    A::Union{CUSPARSE.CudaSparseMatrixCSR{Float32}, Hermitian{Float32,CUSPARSE.CudaSparseMatrixCSR{Float32}}, Symmetric{Float32,CUSPARSE.CudaSparseMatrixCSR{Float32}}}
    X::CUDArt.CudaArray{Float32,1}, beta::Float32
    Y::CUDArt.CudaArray{Float32,1}
    index::Char)
in CUSPARSE at /home/tbesard/Projects/Julia-CUDA/CUSPARSE/src/sparse.jl:738

Possible fix, define
  mv!(::Char, ::Float32, ::CUSPARSE.CudaSparseMatrixCSR{Float32}, ::CUDArt.CudaArray{Float32,1}, ::Float32, ::CUDArt.CudaArray{Float32,1}, ::Char)

```